### PR TITLE
Add Completion to continue mapping on a void method that throws Exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>no.finn.lambda</groupId>
     <artifactId>lambda-companion</artifactId>
-    <version>0.25</version>
+    <version>0.26</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>no.finn.lambda</groupId>
     <artifactId>lambda-companion</artifactId>
-    <version>0.24</version>
+    <version>0.25</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/no/finn/lambdacompanion/Completion.java
+++ b/src/main/java/no/finn/lambdacompanion/Completion.java
@@ -1,0 +1,7 @@
+package no.finn.lambdacompanion;
+
+/**
+ * A class representing a successful completion of a method that would otherwise be void
+ */
+public final class Completion {
+}

--- a/src/main/java/no/finn/lambdacompanion/ThrowingBiConsumer.java
+++ b/src/main/java/no/finn/lambdacompanion/ThrowingBiConsumer.java
@@ -1,0 +1,8 @@
+package no.finn.lambdacompanion;
+
+@FunctionalInterface
+public interface ThrowingBiConsumer<T, R, E extends Exception> {
+
+    void accept(T t, R r) throws E;
+
+}

--- a/src/main/java/no/finn/lambdacompanion/Try.java
+++ b/src/main/java/no/finn/lambdacompanion/Try.java
@@ -178,8 +178,47 @@ public abstract class Try<T> {
         }
     }
 
+    /**
+     * Create a Failure from an Exception
+     * @param Exception base exception
+     * @param <U> Type of returned Try
+     * @return a Failure
+     */
     public static <U> Try<U> failure(Exception Exception) {
         return new Failure<>(Exception);
+    }
+
+    /**
+     * Enhance a void method to return a Try of type Completion
+     * @param throwingConsumer void function throwing Exception
+     * @param param parameter to void function
+     * @param <U> type of void function param
+     * @return Success of Completion or a Failure
+     */
+    public static <U> Try<Completion> completion(ThrowingConsumer<U, ? extends Exception> throwingConsumer, U param) {
+        try {
+            throwingConsumer.accept(param);
+            return new Success<>(new Completion());
+        } catch (Exception e) {
+            return Try.failure(e);
+        }
+     }
+
+    /**
+     * Enhance a void method to return a Try of type Completion
+     * @param throwingBiConsumer void function throwing Exception
+     * @param firstParam first parameter to void function
+     * @param secondParam second parameter to void function
+     * @param <U> type of void function param
+     * @return Success of Completion or a Failure
+     */
+    public static <U, R> Try<Completion> completion(ThrowingBiConsumer<U, R, ? extends Exception> throwingBiConsumer, U firstParam, R secondParam) {
+        try {
+            throwingBiConsumer.accept(firstParam, secondParam);
+            return new Success<>(new Completion());
+        } catch (Exception e) {
+            return Try.failure(e);
+        }
     }
 
     /**


### PR DESCRIPTION
private void demonstrate() {
    Try.completion(this::printStuff, "fisk").map(Object::hashCode).forEach(i -> onlyIfSuccessful());
}

private void printStuff(String s) throws Exception {
    throw new Exception(":(");
}

private void onlyIfSuccessful() throws Exception {
    System.out.println("great");
}
