### PR TITLE
Add @Deprecated annotations to all classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+
+# Deprecation Notice
+This project is no longer being maintained, and its usage should be replaced with JavaSlang
+
+
 # Purpose
 
 This project adds some concepts that didn't ship with java 8 lambda project like Either<L,R> or Pair<L,R> etc...

--- a/src/main/java/no/finn/lambdacompanion/Either.java
+++ b/src/main/java/no/finn/lambdacompanion/Either.java
@@ -15,6 +15,7 @@ import java.util.function.Supplier;
  * @param <L> type of the left side
  * @param <R> type of the right side
  */
+@Deprecated
 public abstract class Either<L, R> {
 
     /**

--- a/src/main/java/no/finn/lambdacompanion/ExtendedStream.java
+++ b/src/main/java/no/finn/lambdacompanion/ExtendedStream.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
  * Wrapper around an {@link java.util.stream.Stream} that provides some missed functions like
  * {@link #foldRight(java.util.function.BiFunction, Object)}, {@link #toList()} and {@link #toSet()}
  */
+@Deprecated
 public class ExtendedStream<T> implements Stream<T> {
 
     private final Stream<T> delegate;

--- a/src/main/java/no/finn/lambdacompanion/Failure.java
+++ b/src/main/java/no/finn/lambdacompanion/Failure.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+@Deprecated
 public class Failure<T> extends Try<T> {
 
     private Exception e;

--- a/src/main/java/no/finn/lambdacompanion/Functions.java
+++ b/src/main/java/no/finn/lambdacompanion/Functions.java
@@ -3,6 +3,7 @@ package no.finn.lambdacompanion;
 import java.util.List;
 import java.util.function.BiFunction;
 
+@Deprecated
 public final class Functions {
 
     private Functions() {

--- a/src/main/java/no/finn/lambdacompanion/Optionals.java
+++ b/src/main/java/no/finn/lambdacompanion/Optionals.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+@Deprecated
 public final class Optionals {
 
     private Optionals() {

--- a/src/main/java/no/finn/lambdacompanion/Pair.java
+++ b/src/main/java/no/finn/lambdacompanion/Pair.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
  * @param <L> type of the left side
  * @param <R> type of the right side
  */
+@Deprecated
 public final class Pair<L, R> {
 
     private final L left;

--- a/src/main/java/no/finn/lambdacompanion/StreamableOptional.java
+++ b/src/main/java/no/finn/lambdacompanion/StreamableOptional.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
  * }
  * </pre>
  */
+@Deprecated
 public class StreamableOptional<T> {
 
     private static final StreamableOptional<?> EMPTY = new StreamableOptional(Optional.empty());

--- a/src/main/java/no/finn/lambdacompanion/Streams.java
+++ b/src/main/java/no/finn/lambdacompanion/Streams.java
@@ -6,6 +6,7 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Deprecated
 public final class Streams {
 
     public static <T> ExtendedStream<T> stream(final Collection<T> collection) {

--- a/src/main/java/no/finn/lambdacompanion/Success.java
+++ b/src/main/java/no/finn/lambdacompanion/Success.java
@@ -7,6 +7,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+@Deprecated
 public class Success<T> extends Try<T> {
 
     private T t;

--- a/src/main/java/no/finn/lambdacompanion/Try.java
+++ b/src/main/java/no/finn/lambdacompanion/Try.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
  *
  * @param <T> t
  */
+@Deprecated
 public abstract class Try<T> {
 
     /**


### PR DESCRIPTION
I would like to add the @Deprecated annotation to lambda-companion in an attempt to keep people from making new things with lambda-companion in projects like m.finn and apps-proxy. It's non-trivial to remove the dependency to lambda-companion in these projects, but at least we can try to encourage people to use javaslang instead. 